### PR TITLE
TASK: EEL-helper completion should exclude inaccessible methods

### DIFF
--- a/src/main/java/de/vette/idea/neos/lang/fusion/completion/EelProvider.java
+++ b/src/main/java/de/vette/idea/neos/lang/fusion/completion/EelProvider.java
@@ -50,6 +50,12 @@ public class EelProvider extends CompletionProvider<CompletionParameters> {
                     Collection<PhpClass> classes = PhpIndex.getInstance(project).getClassesByFQN(helper);
                     for (PhpClass phpClass : classes) {
                         for (Method method : phpClass.getMethods()) {
+                            if (method.getAccess().isPrivate() || method.getAccess().isProtected()) {
+                                continue;
+                            }
+                            if (method.getName().equals("allowsCallOfMethod")) {
+                                continue;
+                            }
                             String completionText = eelHelper + "." + method.getName() + "()";
                             result.addElement(LookupElementBuilder.create(completionText).withIcon(PhpIcons.METHOD_ICON));
                         }

--- a/src/main/java/de/vette/idea/neos/lang/fusion/completion/EelProvider.java
+++ b/src/main/java/de/vette/idea/neos/lang/fusion/completion/EelProvider.java
@@ -50,7 +50,7 @@ public class EelProvider extends CompletionProvider<CompletionParameters> {
                     Collection<PhpClass> classes = PhpIndex.getInstance(project).getClassesByFQN(helper);
                     for (PhpClass phpClass : classes) {
                         for (Method method : phpClass.getMethods()) {
-                            if (method.getAccess().isPrivate() || method.getAccess().isProtected()) {
+                            if (!method.getAccess().isPublic()) {
                                 continue;
                             }
                             if (method.getName().equals("allowsCallOfMethod")) {


### PR DESCRIPTION
The internal "allowsCallOfMethod" method and non-public methods can't be called in EEL an should not be suggested for auto completion.