### PR TITLE
FEATURE: generate node-type references for other occurrences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,8 @@
 
 ## [Unreleased]
 ### Added
+- Node type references in childNodes and editorOptions.nodeTypes
 
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
 ## [1.6.1]
 ### Fixed
 - Exception when using completion for prototypes

--- a/src/main/java/de/vette/idea/neos/lang/yaml/references/nodeType/NodeTypeReference.java
+++ b/src/main/java/de/vette/idea/neos/lang/yaml/references/nodeType/NodeTypeReference.java
@@ -11,20 +11,58 @@ import com.intellij.util.indexing.FileBasedIndex;
 import de.vette.idea.neos.indexes.NodeTypesYamlFileIndex;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.yaml.YAMLUtil;
-import org.jetbrains.yaml.psi.YAMLFile;
-import org.jetbrains.yaml.psi.YAMLKeyValue;
+import org.jetbrains.yaml.psi.*;
+
 import java.util.Collection;
 
 /**
  * Resolving the Node Type when it is clicked
  */
-public class NodeTypeReference extends PsiPolyVariantReferenceBase<YAMLKeyValue> {
-    private final YAMLKeyValue yamlElement;
+public class NodeTypeReference extends PsiPolyVariantReferenceBase<YAMLPsiElement> {
+    private final YAMLPsiElement yamlElement;
+    private final String nodeTypeName;
+
+    private static TextRange textRangeFromElement(YAMLPsiElement yamlElement, boolean isKey) {
+        int sourceStart = 0;
+        int sourceEnd = yamlElement.getTextLength();
+        if (isKey && yamlElement instanceof YAMLKeyValue) {
+            sourceEnd = ((YAMLKeyValue) yamlElement).getKey().getTextLength();
+        } else if (yamlElement instanceof YAMLKeyValue) {
+            sourceStart = ((YAMLKeyValue) yamlElement).getValue().getStartOffsetInParent();
+            sourceEnd = ((YAMLKeyValue) yamlElement).getValue().getTextLength();
+        } else if (yamlElement instanceof YAMLSequenceItem) {
+            sourceStart = ((YAMLSequenceItem) yamlElement).getValue().getStartOffsetInParent();
+            sourceEnd = ((YAMLSequenceItem) yamlElement).getValue().getTextLength();
+        } else {
+            return yamlElement.getTextRange();
+        }
+        return new TextRange(sourceStart, sourceStart + sourceEnd);
+    }
+
+    public NodeTypeReference(YAMLKeyValue yamlElement, boolean isKey) {
+        // the "textRange" is used for highlighting the source element
+        super(yamlElement, textRangeFromElement(yamlElement, isKey));
+        this.yamlElement = yamlElement;
+        if (isKey) {
+            this.nodeTypeName = yamlElement.getKeyText();
+        } else {
+            this.nodeTypeName = yamlElement.getValueText();
+        }
+    }
 
     NodeTypeReference(YAMLKeyValue yamlElement) {
-        // the "textRange" is used for highlighting the source element
-        super(yamlElement, new TextRange(0, yamlElement.getKey().getTextLength() - 1));
+        this(yamlElement, true);
+    }
+
+    NodeTypeReference(YAMLSequenceItem yamlElement) {
+        super(yamlElement.getValue() == null ? yamlElement : yamlElement.getValue(), textRangeFromElement(yamlElement, false));
         this.yamlElement = yamlElement;
+        var textValue = yamlElement.getValue().getText();
+        if (yamlElement.getValue() instanceof YAMLQuotedText) {
+            this.nodeTypeName = textValue.substring(1, textValue.length() - 1);
+        } else {
+            this.nodeTypeName = textValue;
+        }
     }
 
     @NotNull
@@ -36,10 +74,9 @@ public class NodeTypeReference extends PsiPolyVariantReferenceBase<YAMLKeyValue>
     @NotNull
     @Override
     public ResolveResult[] multiResolve(boolean incompleteCode) {
-        String nodeTypeNameToFindReferenceFor = yamlElement.getKeyText();
 
         // files which contain the NodeType definition
-        Collection<VirtualFile> files = FileBasedIndex.getInstance().getContainingFiles(NodeTypesYamlFileIndex.KEY, nodeTypeNameToFindReferenceFor, GlobalSearchScope.allScope(yamlElement.getProject()));
+        Collection<VirtualFile> files = FileBasedIndex.getInstance().getContainingFiles(NodeTypesYamlFileIndex.KEY, nodeTypeName, GlobalSearchScope.allScope(yamlElement.getProject()));
 
         return files
                 .stream()
@@ -51,7 +88,7 @@ public class NodeTypeReference extends PsiPolyVariantReferenceBase<YAMLKeyValue>
                 // get all YAML keys in these files
                 .flatMap(yamlFile -> YAMLUtil.getTopLevelKeys(yamlFile).stream())
                 // get the correct YAML key
-                .filter(yamlKeyValue -> yamlKeyValue.getKeyText().equals(nodeTypeNameToFindReferenceFor))
+                .filter(yamlKeyValue -> yamlKeyValue.getKeyText().equals(nodeTypeName))
                 // remove "current" element if it exists
                 .filter(yamlKeyValue -> yamlElement != yamlKeyValue)
                 // build up the result object

--- a/src/main/java/de/vette/idea/neos/lang/yaml/references/nodeType/NodeTypeReference.java
+++ b/src/main/java/de/vette/idea/neos/lang/yaml/references/nodeType/NodeTypeReference.java
@@ -24,19 +24,18 @@ public class NodeTypeReference extends PsiPolyVariantReferenceBase<YAMLPsiElemen
 
     private static TextRange textRangeFromElement(YAMLPsiElement yamlElement, boolean isKey) {
         int sourceStart = 0;
-        int sourceEnd = yamlElement.getTextLength();
+        int sourceLength;
         if (isKey && yamlElement instanceof YAMLKeyValue) {
-            sourceEnd = ((YAMLKeyValue) yamlElement).getKey().getTextLength();
+            sourceLength = ((YAMLKeyValue) yamlElement).getKey().getTextLength();
         } else if (yamlElement instanceof YAMLKeyValue) {
             sourceStart = ((YAMLKeyValue) yamlElement).getValue().getStartOffsetInParent();
-            sourceEnd = ((YAMLKeyValue) yamlElement).getValue().getTextLength();
+            sourceLength = ((YAMLKeyValue) yamlElement).getValue().getTextLength();
         } else if (yamlElement instanceof YAMLSequenceItem) {
-            sourceStart = ((YAMLSequenceItem) yamlElement).getValue().getStartOffsetInParent();
-            sourceEnd = ((YAMLSequenceItem) yamlElement).getValue().getTextLength();
+            sourceLength = ((YAMLSequenceItem) yamlElement).getValue().getTextLength();
         } else {
             return yamlElement.getTextRange();
         }
-        return new TextRange(sourceStart, sourceStart + sourceEnd);
+        return new TextRange(sourceStart, sourceStart + sourceLength);
     }
 
     public NodeTypeReference(YAMLKeyValue yamlElement, boolean isKey) {

--- a/src/main/java/de/vette/idea/neos/lang/yaml/references/nodeType/NodeTypeReferenceContributor.java
+++ b/src/main/java/de/vette/idea/neos/lang/yaml/references/nodeType/NodeTypeReferenceContributor.java
@@ -11,6 +11,9 @@ import com.intellij.util.ProcessingContext;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.yaml.psi.YAMLKeyValue;
+import org.jetbrains.yaml.psi.YAMLPsiElement;
+import org.jetbrains.yaml.psi.YAMLScalar;
+import org.jetbrains.yaml.psi.YAMLSequenceItem;
 
 /**
  * Entry point for "go to definition" "cmd-click" on a node type name in NodeTypes.yaml to jump to its definition.
@@ -20,11 +23,52 @@ public class NodeTypeReferenceContributor extends PsiReferenceContributor {
     public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
         registrar.registerReferenceProvider(
                 PlatformPatterns.psiElement(YAMLKeyValue.class),
-                new NodeTypeReferenceProvider()
+                new KeyValueNodeTypeReferenceProvider()
+        );
+        registrar.registerReferenceProvider(
+                PlatformPatterns.psiElement(YAMLScalar.class)
+                    .withAncestor(1, PlatformPatterns.psiElement(YAMLSequenceItem.class)),
+                new SequenceItemNodeTypeReferenceProvider()
         );
     }
 
-    private static class NodeTypeReferenceProvider extends PsiReferenceProvider {
+    private static abstract class AbstractNodeTypeReferenceProvider extends PsiReferenceProvider {
+
+        /**
+         * Helper functions to walk the yaml tree
+         */
+        protected static boolean parentKeyIs(YAMLKeyValue yamlKeyValue, String parentKey) {
+            YAMLKeyValue key = getParentKey(yamlKeyValue);
+            return (key != null && parentKey.equals(key.getKeyText()));
+        }
+
+        protected static boolean grandparentKeyIs(YAMLKeyValue yamlKeyValue, String grandparentKey) {
+            YAMLKeyValue key = getParentKey(yamlKeyValue);
+            if (key != null) {
+                key = getParentKey(key);
+                return (key != null && grandparentKey.equals(key.getKeyText()));
+            }
+            return false;
+        }
+
+        protected static boolean isOnRootLevel(YAMLKeyValue yamlKeyValue) {
+            return getParentKey(yamlKeyValue) == null;
+        }
+
+        protected static <T extends YAMLPsiElement> T getParent(YAMLPsiElement yamlElement, Class<T> type) {
+            return PsiTreeUtil.getParentOfType(yamlElement, type);
+        }
+
+        protected static YAMLKeyValue getParentKey(YAMLPsiElement yamlElement) {
+            return getParent(yamlElement, YAMLKeyValue.class);
+        }
+    }
+
+
+    /**
+     * Provide references based on key-value entries, i.e. node-types as configuration keys or simple values
+     */
+    private static class KeyValueNodeTypeReferenceProvider extends AbstractNodeTypeReferenceProvider {
         @NotNull
         @Override
         public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
@@ -35,39 +79,44 @@ public class NodeTypeReferenceContributor extends PsiReferenceContributor {
             // - constraints.nodeTypes
             // - root level (to find other definitions on root)
             if (parentKeyIs(yamlElement, "superTypes")
-                    || (parentKeyIs(yamlElement, "nodeTypes") && grandparentKeyIs(yamlElement, "constraints"))
-                    || isOnRootLevel(yamlElement)) {
+                || (parentKeyIs(yamlElement, "nodeTypes") && grandparentKeyIs(yamlElement, "constraints"))
+                || isOnRootLevel(yamlElement)) {
                 return new PsiReference[]{
-                        new NodeTypeReference(yamlElement)
+                    new NodeTypeReference(yamlElement)
+                };
+            }
+
+            // we also support:
+            // - childNodes.type (works for node-templates as well)
+            if (yamlElement.getKeyText().equals("type") && grandparentKeyIs(yamlElement, "childNodes")) {
+                return new PsiReference[]{
+                    new NodeTypeReference(yamlElement, false)
                 };
             }
 
             return PsiReference.EMPTY_ARRAY;
         }
+    }
 
-        /**
-         * Helper functions to walk the yaml tree
-         */
-        private static boolean parentKeyIs(YAMLKeyValue yamlKeyValue, String parentKey) {
-            YAMLKeyValue key = getParentKey(yamlKeyValue);
-            return (key != null && parentKey.equals(key.getKeyText()));
-        }
+    /**
+     * Provide references based on string lists, i.e. allowed node-types in editor-options
+     */
+    private static class SequenceItemNodeTypeReferenceProvider extends AbstractNodeTypeReferenceProvider {
+        @NotNull
+        @Override
+        public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+            YAMLSequenceItem yamlItem = getParent((YAMLPsiElement) element, YAMLSequenceItem.class);
+            YAMLKeyValue yamlElement = getParentKey(yamlItem);
 
-        private static boolean grandparentKeyIs(YAMLKeyValue yamlKeyValue, String grandparentKey) {
-            YAMLKeyValue key = getParentKey(yamlKeyValue);
-            if (key != null) {
-                key = getParentKey(key);
-                return (key != null && grandparentKey.equals(key.getKeyText()));
+            // we support
+            // - editorOptions.nodeTypes
+            if (yamlElement.getKeyText().equals("nodeTypes") && parentKeyIs(yamlElement, "editorOptions")) {
+                return new PsiReference[]{
+                    new NodeTypeReference(yamlItem)
+                };
             }
-            return false;
-        }
 
-        private static boolean isOnRootLevel(YAMLKeyValue yamlKeyValue) {
-            return getParentKey(yamlKeyValue) == null;
-        }
-
-        private static YAMLKeyValue getParentKey(YAMLKeyValue yamlKeyValue) {
-            return PsiTreeUtil.getParentOfType(yamlKeyValue, YAMLKeyValue.class);
+            return PsiReference.EMPTY_ARRAY;
         }
     }
 }

--- a/testData/nodeTypeReferences/NodeTypes.childNodes.yaml
+++ b/testData/nodeTypeReferences/NodeTypes.childNodes.yaml
@@ -1,0 +1,6 @@
+'Neos.NodeTypes:Item':
+  abstract: true
+'Neos.NodeTypes:Container':
+  childNodes:
+    item:
+      type: 'Neos.NodeTypes:I<caret>tem'

--- a/testData/nodeTypeReferences/NodeTypes.references.yaml
+++ b/testData/nodeTypeReferences/NodeTypes.references.yaml
@@ -1,0 +1,22 @@
+'Neos.NodeTypes:WithInlineReferences':
+  abstract: true
+  properties:
+    references:
+      type: references
+      ui:
+        inspector:
+          editorOptions:
+            nodeTypes: ['Neos.NodeTypes:H<caret>eadline', Neos.NodeTypes:T<caret>ext]
+'Neos.NodeTypes:WithMultilineReferences':
+  abstract: true
+  properties:
+    references:
+      type: references
+      ui:
+        inspector:
+          editorOptions:
+            nodeTypes:
+              - 'Neos.NodeTypes:H<caret>eadline'
+              - Neos.NodeTypes:T<caret>ext
+              -
+                Neos.NodeTypes:Im<caret>age


### PR DESCRIPTION
it should be possible to find references in
* `childNodes.*.type` (scalar value) (works for both normal childNodes as well as node-templates)
* `editorOptions.nodeTypes` (array value)

This change prepares the structure for referencing node-types which are not used as yaml keys and implements references for the aforementioned structures.

**Current pain-points**
- [X] TextRange is not correctly generated for some array values (see below)
- [ ] Handling of quoted text in `NodeTypeReference` doesn't seem optimal, but I somehow failed to get the text-value
- [ ] Maybe it makes sense to make the `NodeTypeReference` generic as `YAMLPsiElement` is a bit vague, but I don't think that this is that important
- [ ] I'm not sure if it is the best solution to split the `NodeTypeReferenceProvider` the way I did, but as it throws an error if a Reference for a different kind of Psi-element is returned (as per super-constructor in `NodeTypeReference`) than the provider is registered for, it seemed necessary.
- [ ] `YAMLScalar` for the array-item provider is a bit generic, but `YAMLSequenceItem` seems not to be something you can actually click on. In that regard it might have been possible to handle simple scalar values like `childNodes.*.type` in this provider as well...
- [X] Add tests...

---

When testing, text-ranges worked for inline-arrays like `nodeTypes: ['Some.Package:Example1', 'Some.Package:Example2']`, but for multi-line arrays everything was broken: example1 would work at a wrong offset, example2 would work without underlining the item.
```
editorOptions:
  nodeTypes:
    - Some.Package:Example1
    - 'Some.Package:Example2'
    -
      'Some.Package.Example3'
```