### PR TITLE
FEATURE: provide node-type and fusion prototype declarations as symbols

### DIFF
--- a/src/main/java/de/vette/idea/neos/search/FusionPrototypeDeclarationContributor.java
+++ b/src/main/java/de/vette/idea/neos/search/FusionPrototypeDeclarationContributor.java
@@ -1,0 +1,65 @@
+package de.vette.idea.neos.search;
+
+import com.intellij.navigation.ChooseByNameContributorEx;
+import com.intellij.navigation.NavigationItem;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.NavigatablePsiElement;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.stubs.StubIndex;
+import com.intellij.util.Processor;
+import com.intellij.util.indexing.FindSymbolParameters;
+import com.intellij.util.indexing.IdFilter;
+import de.vette.idea.neos.lang.fusion.icons.FusionIcons;
+import de.vette.idea.neos.lang.fusion.psi.FusionPrototypeSignature;
+import de.vette.idea.neos.lang.fusion.stubs.index.FusionPrototypeDeclarationIndex;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+public class FusionPrototypeDeclarationContributor implements ChooseByNameContributorEx {
+    @Override
+    public void processNames(@NotNull Processor<? super String> processor, @NotNull GlobalSearchScope scope, @Nullable IdFilter filter) {
+        Project project = scope.getProject();
+        assert project != null;
+        var prototypeNames = StubIndex.getInstance()
+            .getAllKeys(FusionPrototypeDeclarationIndex.KEY, project);
+        prototypeNames.forEach(prototypeName -> {
+            var prototypeSignatures = StubIndex
+                .getElements(FusionPrototypeDeclarationIndex.KEY, prototypeName, project, scope, FusionPrototypeSignature.class);
+            prototypeSignatures.forEach(signature -> {
+                if (signature.getType() != null) {
+                    processor.process(signature.getType().getText());
+                }
+            });
+        });
+    }
+
+    @Override
+    public void processElementsWithName(@NotNull String name, @NotNull Processor<? super NavigationItem> processor, @NotNull FindSymbolParameters parameters) {
+        var nameParts = name.split(":");
+        var indexedName = nameParts.length > 1 ? nameParts[1] : name;
+        Collection<FusionPrototypeSignature> prototypes = StubIndex.getElements(FusionPrototypeDeclarationIndex.KEY, indexedName, parameters.getProject(), parameters.getSearchScope(), FusionPrototypeSignature.class);
+        prototypes.forEach(prototypeSignature -> {
+            if (prototypeSignature.getType() != null) {
+                var navigationItem = new FusionPrototypeNavigationItem(
+                    prototypeSignature,
+                    prototypeSignature.getType().getText()
+                );
+                processor.process(navigationItem);
+            }
+        });
+    }
+
+    private static class FusionPrototypeNavigationItem extends de.vette.idea.neos.search.NavigationItem {
+        /**
+         * Creates a new display item.
+         *
+         * @param psiElement The PsiElement to navigate to.
+         * @param text       Text to show for this element.
+         */
+        public FusionPrototypeNavigationItem(@NotNull NavigatablePsiElement psiElement, @NotNull String text) {
+            super(psiElement, text, FusionIcons.PROTOTYPE);
+        }
+    }
+}

--- a/src/main/java/de/vette/idea/neos/search/NavigationItem.java
+++ b/src/main/java/de/vette/idea/neos/search/NavigationItem.java
@@ -1,0 +1,69 @@
+package de.vette.idea.neos.search;
+
+import com.intellij.navigation.ItemPresentation;
+import com.intellij.openapi.util.NlsSafe;
+import com.intellij.psi.NavigatablePsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.presentation.java.SymbolPresentationUtil;
+import com.intellij.util.xml.model.gotosymbol.GoToSymbolProvider;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class NavigationItem extends GoToSymbolProvider.BaseNavigationItem {
+
+    protected NavigatablePsiElement psiElement;
+    protected String label;
+    protected Icon icon;
+
+    /**
+     * Creates a new display item.
+     *
+     * @param psiElement The PsiElement to navigate to.
+     * @param text       Text to show for this element.
+     * @param icon       Icon to show for this element.
+     */
+    public NavigationItem(@NotNull NavigatablePsiElement psiElement, @NotNull @NonNls String text, @Nullable Icon icon) {
+        super(psiElement, text, icon);
+        this.psiElement = psiElement;
+        this.label = text;
+        this.icon = icon;
+    }
+
+    @Override
+    public ItemPresentation getPresentation() {
+        return new FlowSourceItemPresentation(psiElement.getContainingFile(), label);
+    }
+
+    public class FlowSourceItemPresentation implements ItemPresentation {
+
+        private final PsiFile file;
+        private final String label;
+
+        /**
+         * @param file          The file containing the navigation item
+         * @param label         The text displayed in the navigation item
+         */
+        public FlowSourceItemPresentation(PsiFile file, String label) {
+            this.file = file;
+            this.label = label;
+        }
+
+        @Override
+        public @NlsSafe String getPresentableText() {
+            return label;
+        }
+
+        @Override
+        public @NlsSafe  String getLocationString() {
+            return SymbolPresentationUtil.getFilePathPresentation(file);
+        }
+
+        @Override
+        public @Nullable Icon getIcon(boolean unused) {
+            return icon;
+        }
+    }
+}

--- a/src/main/java/de/vette/idea/neos/search/NodeTypeContributor.java
+++ b/src/main/java/de/vette/idea/neos/search/NodeTypeContributor.java
@@ -1,0 +1,58 @@
+package de.vette.idea.neos.search;
+
+import com.intellij.navigation.ChooseByNameContributorEx;
+import com.intellij.navigation.NavigationItem;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.NavigatablePsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.util.Processor;
+import com.intellij.util.indexing.FileBasedIndex;
+import com.intellij.util.indexing.FindSymbolParameters;
+import com.intellij.util.indexing.IdFilter;
+import de.vette.idea.neos.NeosIcons;
+import de.vette.idea.neos.indexes.NodeTypesYamlFileIndex;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.yaml.YAMLUtil;
+import org.jetbrains.yaml.psi.YAMLFile;
+
+
+public class NodeTypeContributor implements ChooseByNameContributorEx {
+    @Override
+    public void processNames(@NotNull Processor<? super String> processor, @NotNull GlobalSearchScope scope, @Nullable IdFilter filter) {
+        Project project = scope.getProject();
+        assert project != null;
+        var nodeTypeNames = FileBasedIndex.getInstance()
+            .getAllKeys(NodeTypesYamlFileIndex.KEY, project);
+        nodeTypeNames.forEach(processor::process);
+    }
+
+    @Override
+    public void processElementsWithName(@NotNull String name, @NotNull Processor<? super NavigationItem> processor, @NotNull FindSymbolParameters parameters) {
+        var files = FileBasedIndex.getInstance()
+            .getContainingFiles(NodeTypesYamlFileIndex.KEY, name, parameters.getSearchScope());
+        var psiManager = PsiManager.getInstance(parameters.getProject());
+        files.forEach(file -> {
+            PsiFile psiFile = psiManager.findFile(file);
+            if (psiFile instanceof YAMLFile) {
+                var definitionTarget = YAMLUtil.getTopLevelKeys((YAMLFile) psiFile)
+                    .stream().filter(yamlKeyValue -> yamlKeyValue.getKeyText().equals(name)).findFirst();
+                definitionTarget.ifPresent(yamlKeyValue -> processor.process(new NodeTypeNavigationItem(yamlKeyValue, name)));
+            }
+        });
+    }
+
+    private static class NodeTypeNavigationItem extends de.vette.idea.neos.search.NavigationItem {
+        /**
+         * Creates a new display item.
+         *
+         * @param psiElement The PsiElement to navigate to.
+         * @param text       Text to show for this element.
+         */
+        public NodeTypeNavigationItem(@NotNull NavigatablePsiElement psiElement, @NotNull String text) {
+            super(psiElement, text, NeosIcons.NODE_TYPE);
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -85,6 +85,8 @@
     <annotator language="NeosFusion" implementationClass="de.vette.idea.neos.lang.fusion.annotators.EelHelperMethodAnnotator"/>
     <annotator language="NeosFusion" implementationClass="de.vette.idea.neos.lang.fusion.annotators.PrototypeInheritanceAnnotator"/>
 
+    <gotoSymbolContributor implementation="de.vette.idea.neos.search.NodeTypeContributor"/>
+
     <!-- Line Marker Providers -->
     <codeInsight.lineMarkerProvider language="NeosFusion" implementationClass="de.vette.idea.neos.lang.fusion.annotators.NodeTypeLineMarkerProvider"/>
     <codeInsight.lineMarkerProvider language="yaml" implementationClass="de.vette.idea.neos.lang.yaml.annotators.PrototypeLineMarkerProvider"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -86,6 +86,7 @@
     <annotator language="NeosFusion" implementationClass="de.vette.idea.neos.lang.fusion.annotators.PrototypeInheritanceAnnotator"/>
 
     <gotoSymbolContributor implementation="de.vette.idea.neos.search.NodeTypeContributor"/>
+    <gotoSymbolContributor implementation="de.vette.idea.neos.search.FusionPrototypeDeclarationContributor"/>
 
     <!-- Line Marker Providers -->
     <codeInsight.lineMarkerProvider language="NeosFusion" implementationClass="de.vette.idea.neos.lang.fusion.annotators.NodeTypeLineMarkerProvider"/>


### PR DESCRIPTION
Node-types and fusion prototype declarations can be reached through the "go to symbol" dialog.

(Prototypes sadly can't be found when using their namespace. I maybe have something wrong when getting the name from the `FusionPrototypeSignature`)