### PR TITLE
FEATURE: add action to copy resource URI for a package resource

### DIFF
--- a/src/main/java/de/vette/idea/neos/actions/CopyResourceUri.java
+++ b/src/main/java/de/vette/idea/neos/actions/CopyResourceUri.java
@@ -1,0 +1,100 @@
+/*
+ *  IntelliJ IDEA plugin to support the Neos CMS.
+ *  Copyright (C) 2016  Christian Vette
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.vette.idea.neos.actions;
+
+import com.intellij.ide.actions.CopyPathProvider;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import de.vette.idea.neos.NeosIcons;
+import de.vette.idea.neos.util.ComposerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+public class CopyResourceUri extends CopyPathProvider {
+
+    @Override
+    public void update(@NotNull AnActionEvent e)
+    {
+        super.update(e);
+        e.getPresentation().setIcon(NeosIcons.NODE_TYPE);
+    }
+
+    @Nullable
+    @Override
+    public String getPathToElement(@NotNull Project project, @Nullable VirtualFile virtualFile, @Nullable Editor editor)
+    {
+        if (virtualFile == null) {
+            return null;
+        }
+        var psiFile = PsiManager.getInstance(project).findFile(virtualFile);
+        if (psiFile == null) {
+            return null;
+        }
+
+        var packageKey = getClosestPackageKey(psiFile);
+        if (packageKey == null) {
+            return null;
+        }
+
+        return getResourceUri(virtualFile, packageKey);
+    }
+
+    private String getResourceUri(VirtualFile file, String packageName)
+    {
+        var pathParts = file.getPath().split("Resources/", 2);
+        if (pathParts.length < 2) {
+            return String.format("resource://%s/", packageName);
+        }
+        return String.format("resource://%s/%s", packageName, pathParts[1]);
+    }
+
+    @Nullable
+    private String getClosestPackageKey(PsiFile file)
+    {
+        var parent = file.getParent();
+        String packageName = null;
+        var contentRoots = Arrays.asList(ProjectRootManager.getInstance(file.getProject()).getContentRoots());
+
+        var resourcesDirectoryFound = false;
+        while (parent != null && !contentRoots.contains(parent.getVirtualFile())) {
+            if (parent.getName().equals("Resources")) {
+                resourcesDirectoryFound = true;
+            } else if (resourcesDirectoryFound) {
+                var composerManifest = ComposerUtil.getComposerManifest(parent);
+                if (composerManifest != null && composerManifest.isValid()) {
+                    packageName = ComposerUtil.getPackageKey(composerManifest);
+                    break;
+                }
+            }
+            parent = parent.getParent();
+        }
+
+        if (!resourcesDirectoryFound) {
+            return null;
+        }
+        return packageName;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -141,5 +141,8 @@
     <action id="Neos.NewFusionFile" class="de.vette.idea.neos.actions.CreateFusionFile" text="Fusion File" description="Create new Fusion file">
       <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFromTemplate"/>
     </action>
+    <action id="Neos.CopyResourceUri" class="de.vette.idea.neos.actions.CopyResourceUri" text="Copy resource:// URI" description="Copies the flow resource:// URI of the current file">
+      <add-to-group group-id="CopyFileReference"/>
+    </action>
   </actions>
 </idea-plugin>

--- a/src/test/java/de/vette/idea/neos/util/ComposerUtilTest.java
+++ b/src/test/java/de/vette/idea/neos/util/ComposerUtilTest.java
@@ -1,0 +1,54 @@
+package de.vette.idea.neos.util;
+
+import com.intellij.json.psi.JsonFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+public class ComposerUtilTest extends BasePlatformTestCase {
+
+    public void testExtraPackageKey()
+    {
+        var manifest = loadComposerFile("package-with-package-key.json");
+        var packageKey = ComposerUtil.getPackageKey(manifest);
+        assertEquals("Acme.PackageKey", packageKey);
+    }
+
+    public void testAutoloadPackageKey()
+    {
+        var manifest = loadComposerFile("package-with-autoload.json");
+        var packageKey = ComposerUtil.getPackageKey(manifest);
+        // autoload-order is not reliable in this implementation
+        assertEquals("Acme.First.Namespace", packageKey);
+    }
+
+    public void testDirectoryStructurePackageKey()
+    {
+        var manifest = loadComposerFile("package-with-path.json", "Packages/Application/Acme.PathPackage/composer.json");
+        var packageKey = ComposerUtil.getPackageKey(manifest);
+        assertEquals("Acme.PathPackage", packageKey);
+    }
+
+    public void testNamePackageKey()
+    {
+        var manifest = loadComposerFile("package-with-name.json");
+        var packageKey = ComposerUtil.getPackageKey(manifest);
+        // a package-key derived from the package name will not get case-converted
+        assertEquals("acme.example", packageKey);
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/composer";
+    }
+
+    private JsonFile loadComposerFile(String fixtureName) {
+        return loadComposerFile(fixtureName, "composer.json");
+    }
+
+    private JsonFile loadComposerFile(String fixtureName, String filePath)
+    {
+        var file = myFixture.copyFileToProject(fixtureName, filePath);
+        var psiFile = PsiManager.getInstance(getProject()).findFile(file);
+        return (JsonFile) psiFile;
+    }
+}

--- a/testData/composer/package-with-autoload.json
+++ b/testData/composer/package-with-autoload.json
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-4": {
+            "Acme\\First\\Namespace": "Classes1"
+        }
+    }
+}

--- a/testData/composer/package-with-name.json
+++ b/testData/composer/package-with-name.json
@@ -1,0 +1,4 @@
+{
+    "name": "acme/example",
+    "type": "neos-package"
+}

--- a/testData/composer/package-with-package-key.json
+++ b/testData/composer/package-with-package-key.json
@@ -1,0 +1,9 @@
+{
+    "name": "acme/example",
+    "type": "neos-package",
+    "extra": {
+        "neos": {
+            "package-key": "Acme.PackageKey"
+        }
+    }
+}

--- a/testData/composer/package-with-path.json
+++ b/testData/composer/package-with-path.json
@@ -1,0 +1,3 @@
+{
+    "type": "neos-package"
+}


### PR DESCRIPTION
Adds an entry to the "copy references" popup to copy the resource:// URI of a file to the clipboard.

For this I added a few utility function to the existing `ComposerUtil` to get the package key from a composer manifest.