### PR TITLE
feat: fusion path intentions

### DIFF
--- a/src/main/java/de/vette/idea/neos/lang/fusion/codeInsight/intention/GroupFusionPaths.java
+++ b/src/main/java/de/vette/idea/neos/lang/fusion/codeInsight/intention/GroupFusionPaths.java
@@ -1,0 +1,168 @@
+package de.vette.idea.neos.lang.fusion.codeInsight.intention;
+
+import com.intellij.codeInsight.intention.BaseElementAtCaretIntentionAction;
+import com.intellij.codeInspection.util.IntentionFamilyName;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiWhiteSpace;
+import com.intellij.psi.codeStyle.CodeStyleManager;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.IncorrectOperationException;
+import de.vette.idea.neos.lang.fusion.FusionBundle;
+import de.vette.idea.neos.lang.fusion.psi.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GroupFusionPaths extends BaseElementAtCaretIntentionAction {
+    @Override
+    public boolean isAvailable(@NotNull Project project, @NotNull Editor editor, @NotNull PsiElement element) {
+        if (!(element.getContainingFile() instanceof FusionFile)) {
+            return false;
+        }
+        if (element.getNode().getElementType() != FusionTypes.PATH_SEPARATOR) {
+            return false;
+        }
+        var path = PsiTreeUtil.findFirstParent(element, true, e -> e instanceof FusionPath);
+        if (path == null) {
+            return false;
+        }
+        var prefix = getPathPrefix((FusionPath) path, element);
+        var context = getContext(element);
+        var siblingCandidates = getElementsInPath(prefix, context);
+        this.setText(FusionBundle.message("intention.group.fusion.paths.of", prefix));
+        return siblingCandidates.size() > 1;
+    }
+
+    protected String getPathPrefix(FusionPath path, PsiElement separator) {
+        var child = path.getFirstChild();
+        StringBuilder prefix = new StringBuilder();
+        while (child != separator) {
+            prefix.append(child.getText());
+            child = child.getNextSibling();
+        }
+        return prefix.toString();
+    }
+
+    protected PsiElement getContext(PsiElement element) {
+        var closestBlock = PsiTreeUtil.findFirstParent(element, true, e -> e instanceof FusionBlock);
+        if (closestBlock != null) {
+            return closestBlock;
+        }
+        // we expect a path always to be within a block or to be at the top level of the file
+        return element.getContainingFile();
+    }
+
+    protected @NotNull List<PsiElement> getElementsInPath(String prefix, PsiElement context) {
+        var prefixLike = prefix + ".";
+        var elements = new ArrayList<PsiElement>();
+
+        for (var child : context.getChildren()) {
+            if (child instanceof FusionPropertyBlock propertyBlock) {
+                var path = propertyBlock.getPath().getText();
+                if (path.equals(prefix) || path.startsWith(prefixLike)) {
+                    elements.add(propertyBlock);
+                }
+            } else if (child instanceof FusionPropertyAssignment assignment) {
+                var path = assignment.getPath().getText();
+                if (path.equals(prefix)) {
+                    // we can only merge into assignments that instantiate a prototype
+                    if (assignment.getAssignmentValue() == null || assignment.getAssignmentValue().getPrototypeInstance() == null) {
+                        return new ArrayList<>();
+                    }
+                    elements.add(assignment);
+                } else if (path.startsWith(prefixLike)) {
+                    elements.add(assignment);
+                }
+            }
+        }
+
+        return elements;
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, @NotNull Editor editor, @NotNull PsiElement element) throws IncorrectOperationException {
+        var path = PsiTreeUtil.findFirstParent(element, true, e -> e instanceof FusionPath);
+        if (path == null) {
+            return;
+        }
+        var prefix = getPathPrefix((FusionPath) path, element);
+        var context = getContext(element);
+        var siblingCandidates = getElementsInPath(prefix, context);
+        if (siblingCandidates.size() < 2) {
+            return;
+        }
+
+        var prefixLength = 1;
+        var prefixStart = path.getFirstChild();
+        while (prefixStart != element) {
+            prefixLength++;
+            prefixStart = prefixStart.getNextSibling();
+        }
+
+        // TODO: check if this would merge into a prototype instantiation: in general that could work, but not with this
+        //  code. Also for some prototypes we might want some order of properties, e.g. any other property before
+        //  "renderer"
+
+        // I would have preferred working with the PSI tree, but I couldn't get correct line breaks within reasonable time
+        var newBlockCode = new StringBuilder();
+        newBlockCode.append(prefix);
+        newBlockCode.append(" {");
+
+        List<PsiElement> elementsToRemove = new ArrayList<>();
+        for (var sibling : siblingCandidates) {
+            FusionPath siblingPath;
+            if (sibling instanceof FusionPropertyBlock propertyBlock) {
+                siblingPath = propertyBlock.getPath();
+            } else if (sibling instanceof FusionPropertyAssignment assignment) {
+                siblingPath = assignment.getPath();
+            } else {
+                continue;
+            }
+
+            // drop prefix from path
+            var removedCount = prefixLength;
+            while (siblingPath.getFirstChild() != null && removedCount > 0) {
+                removedCount--;
+                siblingPath.getFirstChild().delete();
+            }
+
+            elementsToRemove.add(sibling);
+            if (sibling.getNextSibling() instanceof PsiWhiteSpace) {
+                sibling.getNextSibling().delete();
+            }
+
+            if (sibling instanceof FusionPropertyBlock propertyBlock) {
+                var openingBrace = propertyBlock.getBlock().getLeftBrace();
+                var closingBrace = propertyBlock.getBlock().getRightBrace();
+                var child = openingBrace.getNextSibling();
+                while (child != closingBrace) {
+                    if (!(child instanceof PsiWhiteSpace)) {
+                        newBlockCode.append("\n");
+                        newBlockCode.append(child.getText());
+                    }
+                    child = child.getNextSibling();
+                }
+            } else {
+                newBlockCode.append("\n");
+                newBlockCode.append(sibling.getText());
+            }
+        }
+
+        newBlockCode.append("\n}\n");
+        var newBlock = FusionElementFactory.createFusionFile(project, newBlockCode.toString());
+        var addedBlock = (FusionPropertyBlock) siblingCandidates.get(0).getParent().addBefore(newBlock.getFirstChild(), siblingCandidates.get(0));
+        addedBlock.getParent().addAfter(newBlock.getLastChild(), addedBlock);
+
+        elementsToRemove.forEach(PsiElement::delete);
+
+        CodeStyleManager.getInstance(project).reformat(addedBlock);
+    }
+
+    @Override
+    public @NotNull @IntentionFamilyName String getFamilyName() {
+        return FusionBundle.message("intention.group.fusion.paths");
+    }
+}

--- a/src/main/java/de/vette/idea/neos/lang/fusion/codeInsight/intention/MergeFusionPathUp.java
+++ b/src/main/java/de/vette/idea/neos/lang/fusion/codeInsight/intention/MergeFusionPathUp.java
@@ -1,0 +1,88 @@
+package de.vette.idea.neos.lang.fusion.codeInsight.intention;
+
+import com.intellij.codeInsight.intention.BaseElementAtCaretIntentionAction;
+import com.intellij.codeInspection.util.IntentionFamilyName;
+import com.intellij.codeInspection.util.IntentionName;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiWhiteSpace;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.IncorrectOperationException;
+import de.vette.idea.neos.NeosProjectService;
+import de.vette.idea.neos.lang.fusion.FusionBundle;
+import de.vette.idea.neos.lang.fusion.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MergeFusionPathUp extends BaseElementAtCaretIntentionAction {
+    @Override
+    public @NotNull @IntentionName String getText() {
+        return getFamilyName();
+    }
+
+    @Override
+    public @NotNull @IntentionFamilyName String getFamilyName() {
+        return FusionBundle.message("intention.merge.fusion.path.up");
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, @NotNull Editor editor, @NotNull PsiElement element) {
+        if (!(element.getContainingFile() instanceof FusionFile)) {
+            return false;
+        }
+
+        var path = (FusionPath) PsiTreeUtil.findFirstParent(element, true, e -> e instanceof FusionPath);
+
+        var closestBlock = getClosestBlock(path);
+        return closestBlock != null;
+    }
+
+    protected @Nullable FusionPropertyBlock getClosestBlock(@Nullable FusionPath path) {
+        if (path == null || path.getParent() == null || !(path.getParent().getParent() instanceof FusionBlock)) {
+            return null;
+        }
+
+        FusionBlock block = (FusionBlock) path.getParent().getParent();
+        return block.getParent() instanceof FusionPropertyBlock ? (FusionPropertyBlock) block.getParent() : null;
+    }
+
+    protected int getChildrenCount(FusionPropertyBlock block) {
+        return block.getBlock().getChildren().length;
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, @NotNull Editor editor, @NotNull PsiElement element) throws IncorrectOperationException {
+        var path = (FusionPath) PsiTreeUtil.findFirstParent(element, true, e -> e instanceof FusionPath);
+        var block = getClosestBlock(path);
+        if (path == null || block == null) {
+            return;
+        }
+
+        int blockChildrenCount = getChildrenCount(block);
+        NeosProjectService.getLogger().debug("blockChildrenCount: " + blockChildrenCount);
+        var originalStatement = path.getParent();
+        var pathSeparator = FusionElementFactory.createFusionFile(project, "foo.bar").getFirstChild().getNextSibling();
+        var child = block.getPath().getFirstChild();
+        var anchor = path.getFirstChild();
+        while (child != null) {
+            path.addBefore(child.copy(), anchor);
+            child = child.getNextSibling();
+        }
+        path.addBefore(pathSeparator.copy(), anchor);
+        block.getParent().addAfter(originalStatement, block);
+
+        if (blockChildrenCount == 1) {
+            // block should now be empty
+            block.delete();
+        } else {
+            var nl = FusionElementFactory.createFusionFile(project, "\n").getFirstChild();
+            block.getParent().addAfter(nl, block);
+            // remove trailing line break
+            if (originalStatement.getNextSibling() instanceof PsiWhiteSpace) {
+                originalStatement.getNextSibling().delete();
+            }
+            originalStatement.delete();
+        }
+    }
+}

--- a/src/main/java/de/vette/idea/neos/lang/fusion/codeInsight/intention/SplitFusionPath.java
+++ b/src/main/java/de/vette/idea/neos/lang/fusion/codeInsight/intention/SplitFusionPath.java
@@ -1,0 +1,69 @@
+package de.vette.idea.neos.lang.fusion.codeInsight.intention;
+
+import com.intellij.codeInsight.intention.BaseElementAtCaretIntentionAction;
+import com.intellij.codeInspection.util.IntentionFamilyName;
+import com.intellij.codeInspection.util.IntentionName;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.codeStyle.CodeStyleManager;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.IncorrectOperationException;
+import de.vette.idea.neos.lang.fusion.FusionBundle;
+import de.vette.idea.neos.lang.fusion.psi.*;
+import org.jetbrains.annotations.NotNull;
+
+public class SplitFusionPath extends BaseElementAtCaretIntentionAction {
+
+    @Override
+    public @NotNull @IntentionName String getText() {
+        return getFamilyName();
+    }
+
+    @Override
+    public @NotNull @IntentionFamilyName String getFamilyName() {
+        return FusionBundle.message("intention.split.fusion.path");
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, @NotNull Editor editor, @NotNull PsiElement element) {
+        if (!(element.getContainingFile() instanceof FusionFile)) {
+            return false;
+        }
+        if (element.getNode().getElementType() != FusionTypes.PATH_SEPARATOR) {
+            return false;
+        }
+        var path = PsiTreeUtil.findFirstParent(element, true, e -> e instanceof FusionPath);
+        return path != null && path.getChildren().length > 1;
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, @NotNull Editor editor, @NotNull PsiElement element) throws IncorrectOperationException {
+        var path = PsiTreeUtil.findFirstParent(element, true, e -> e instanceof FusionPath);
+        if (path == null) {
+            return;
+        }
+
+        var originalStatement = path.getParent();
+
+        var newBlock = (FusionPropertyBlock) FusionElementFactory.createFusionFile(project, "dummy {\n\n}").getFirstChild();
+        var newPath = newBlock.getPath();
+        var child = path.getFirstChild();
+        while (child != element) {
+            // this seems to create a copy and does not "remount" the element, so we need to delete the original
+            newPath.add(child);
+            var next = child.getNextSibling();
+            child.delete();
+            child = next;
+        }
+        element.delete();
+        newPath.getFirstChild().delete();
+
+        var insertedBlock = (FusionPropertyBlock) originalStatement.getParent().addBefore(newBlock, originalStatement);
+        insertedBlock.getBlock().addAfter(originalStatement, insertedBlock.getBlock().getLeftBrace().getNextSibling());
+
+        originalStatement.delete();
+
+        CodeStyleManager.getInstance(project).reformat(insertedBlock);
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -120,6 +120,12 @@
     <gotoSymbolContributor implementation="de.vette.idea.neos.search.NodeTypeContributor"/>
     <gotoSymbolContributor implementation="de.vette.idea.neos.search.FusionPrototypeDeclarationContributor"/>
 
+    <intentionAction>
+      <language>NeosFusion</language>
+      <className>de.vette.idea.neos.lang.fusion.codeInsight.intention.SplitFusionPath</className>
+      <category>Refactoring</category>
+    </intentionAction>
+
     <!-- Line Marker Providers -->
     <codeInsight.lineMarkerProvider language="NeosFusion" implementationClass="de.vette.idea.neos.lang.fusion.annotators.NodeTypeLineMarkerProvider"/>
     <codeInsight.lineMarkerProvider language="yaml" implementationClass="de.vette.idea.neos.lang.yaml.annotators.PrototypeLineMarkerProvider"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -130,6 +130,11 @@
       <className>de.vette.idea.neos.lang.fusion.codeInsight.intention.MergeFusionPathUp</className>
       <category>Neos Fusion</category>
     </intentionAction>
+    <intentionAction>
+      <language>NeosFusion</language>
+      <className>de.vette.idea.neos.lang.fusion.codeInsight.intention.GroupFusionPaths</className>
+      <category>Neos Fusion</category>
+    </intentionAction>
 
     <!-- Line Marker Providers -->
     <codeInsight.lineMarkerProvider language="NeosFusion" implementationClass="de.vette.idea.neos.lang.fusion.annotators.NodeTypeLineMarkerProvider"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -123,7 +123,12 @@
     <intentionAction>
       <language>NeosFusion</language>
       <className>de.vette.idea.neos.lang.fusion.codeInsight.intention.SplitFusionPath</className>
-      <category>Refactoring</category>
+      <category>Neos Fusion</category>
+    </intentionAction>
+    <intentionAction>
+      <language>NeosFusion</language>
+      <className>de.vette.idea.neos.lang.fusion.codeInsight.intention.MergeFusionPathUp</className>
+      <category>Neos Fusion</category>
     </intentionAction>
 
     <!-- Line Marker Providers -->

--- a/src/main/resources/intentionDescriptions/GroupFusionPaths/after.fusion.template
+++ b/src/main/resources/intentionDescriptions/GroupFusionPaths/after.fusion.template
@@ -1,0 +1,4 @@
+renderer.@process {
+    processor1 = Vendor.Package:StringProcessor
+    processor2 = ${props.prefix + value}
+}

--- a/src/main/resources/intentionDescriptions/GroupFusionPaths/before.fusion.template
+++ b/src/main/resources/intentionDescriptions/GroupFusionPaths/before.fusion.template
@@ -1,0 +1,2 @@
+renderer.@process.processor1 = Vendor.Package:StringProcessor
+renderer.@process.processor2 = ${props.prefix + value}

--- a/src/main/resources/intentionDescriptions/GroupFusionPaths/description.html
+++ b/src/main/resources/intentionDescriptions/GroupFusionPaths/description.html
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+Groups all fusion paths with the prefix before the caret into a single block.
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/MergeFusionPathUp/after.fusion.template
+++ b/src/main/resources/intentionDescriptions/MergeFusionPathUp/after.fusion.template
@@ -1,0 +1,6 @@
+foo.bar = ${value}
+
+foo {
+    baz = ${value2}
+}
+foo.bar = ${value}

--- a/src/main/resources/intentionDescriptions/MergeFusionPathUp/before.fusion.template
+++ b/src/main/resources/intentionDescriptions/MergeFusionPathUp/before.fusion.template
@@ -1,0 +1,8 @@
+foo {
+    bar = ${value}
+}
+
+foo {
+    bar = ${value1}
+    baz = ${value2}
+}

--- a/src/main/resources/intentionDescriptions/MergeFusionPathUp/description.html
+++ b/src/main/resources/intentionDescriptions/MergeFusionPathUp/description.html
@@ -1,0 +1,12 @@
+<html lang="en">
+<body>
+Merges a fusion path to the parent block.
+<p>
+    If a fusion path (as part of an assignment or a block) is within a block, it will be moved to an assignment (or
+    block) with the merged path.
+</p>
+<p>
+    If a block contains multiple paths, only the current path will be pulled out and removed from the block.
+</p>
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/SplitFusionPath/after.fusion.template
+++ b/src/main/resources/intentionDescriptions/SplitFusionPath/after.fusion.template
@@ -1,0 +1,3 @@
+foo {
+    bar.baz = ${value}
+}

--- a/src/main/resources/intentionDescriptions/SplitFusionPath/before.fusion.template
+++ b/src/main/resources/intentionDescriptions/SplitFusionPath/before.fusion.template
@@ -1,0 +1,1 @@
+foo.bar.baz = ${value}

--- a/src/main/resources/intentionDescriptions/SplitFusionPath/description.html
+++ b/src/main/resources/intentionDescriptions/SplitFusionPath/description.html
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+Splits a fusion path into nested blocks at the current path separator.
+</body>
+</html>

--- a/src/main/resources/messages/FusionBundle.properties
+++ b/src/main/resources/messages/FusionBundle.properties
@@ -4,3 +4,5 @@ usage.type.instance=Instance
 usage.type.inherited=Inherited
 intention.split.fusion.path=Split fusion path
 intention.merge.fusion.path.up=Merge fusion path up
+intention.group.fusion.paths=Group fusion paths
+intention.group.fusion.paths.of=Group paths of "{0}"

--- a/src/main/resources/messages/FusionBundle.properties
+++ b/src/main/resources/messages/FusionBundle.properties
@@ -3,3 +3,4 @@ usage.type.deleted=Deleted
 usage.type.instance=Instance
 usage.type.inherited=Inherited
 intention.split.fusion.path=Split fusion path
+intention.merge.fusion.path.up=Merge fusion path up

--- a/src/main/resources/messages/FusionBundle.properties
+++ b/src/main/resources/messages/FusionBundle.properties
@@ -2,3 +2,4 @@ usage.type.definition=Definition
 usage.type.deleted=Deleted
 usage.type.instance=Instance
 usage.type.inherited=Inherited
+intention.split.fusion.path=Split fusion path

--- a/src/test/java/de/vette/idea/neos/fusion/codeInsight/intention/FusionPathIntentionTest.java
+++ b/src/test/java/de/vette/idea/neos/fusion/codeInsight/intention/FusionPathIntentionTest.java
@@ -1,0 +1,28 @@
+package de.vette.idea.neos.fusion.codeInsight.intention;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import util.FusionTestUtils;
+
+import java.io.File;
+
+public class FusionPathIntentionTest extends BasePlatformTestCase {
+    @Override
+    protected @NonNls @NotNull String getTestDataPath() {
+        return FusionTestUtils.BASE_TEST_DATA_PATH + File.separator + "fusion" + File.separator + "codeInsight" + File.separator + "intention";
+    }
+
+    public void testSplitFusionPath() {
+        doTest("splitFusionPath", "Split fusion path");
+    }
+
+    private void doTest(String testName, String hint) {
+        myFixture.configureByFile(testName + ".before.fusion");
+        final IntentionAction action = myFixture.findSingleIntention(hint);
+        assertNotNull(action);
+        myFixture.launchAction(action);
+        myFixture.checkResultByFile(testName + ".after.fusion");
+    }
+}

--- a/src/test/java/de/vette/idea/neos/fusion/codeInsight/intention/FusionPathIntentionTest.java
+++ b/src/test/java/de/vette/idea/neos/fusion/codeInsight/intention/FusionPathIntentionTest.java
@@ -26,6 +26,10 @@ public class FusionPathIntentionTest extends BasePlatformTestCase {
         doTest("mergeSingleFusionPathUp", "Merge fusion path up");
     }
 
+    public void testGroupFusionPaths() {
+        doTest("groupPaths", "Group paths of \"renderer.@process\"");
+    }
+
     private void doTest(String testName, String hint) {
         myFixture.configureByFile(testName + ".before.fusion");
         final IntentionAction action = myFixture.findSingleIntention(hint);

--- a/src/test/java/de/vette/idea/neos/fusion/codeInsight/intention/FusionPathIntentionTest.java
+++ b/src/test/java/de/vette/idea/neos/fusion/codeInsight/intention/FusionPathIntentionTest.java
@@ -18,6 +18,14 @@ public class FusionPathIntentionTest extends BasePlatformTestCase {
         doTest("splitFusionPath", "Split fusion path");
     }
 
+    public void testMergeOnlyFusionPathUp() {
+        doTest("mergeOnlyFusionPathUp", "Merge fusion path up");
+    }
+
+    public void testMergeSingleFusionPathUp() {
+        doTest("mergeSingleFusionPathUp", "Merge fusion path up");
+    }
+
     private void doTest(String testName, String hint) {
         myFixture.configureByFile(testName + ".before.fusion");
         final IntentionAction action = myFixture.findSingleIntention(hint);

--- a/testData/fusion/codeInsight/intention/groupPaths.after.fusion
+++ b/testData/fusion/codeInsight/intention/groupPaths.after.fusion
@@ -1,0 +1,5 @@
+renderer.@process {
+    processor1 = Vendor.Package:StringProcessor
+    processor2 = ${props.prefix + value}
+    processor3 = ${value + props.suffix}
+}

--- a/testData/fusion/codeInsight/intention/groupPaths.before.fusion
+++ b/testData/fusion/codeInsight/intention/groupPaths.before.fusion
@@ -1,0 +1,5 @@
+renderer.@process.processor1 = Vendor.Package:StringProcessor
+renderer.@process<caret>.processor2 = ${props.prefix + value}
+renderer.@process {
+    processor3 = ${value + props.suffix}
+}

--- a/testData/fusion/codeInsight/intention/mergeOnlyFusionPathUp.after.fusion
+++ b/testData/fusion/codeInsight/intention/mergeOnlyFusionPathUp.after.fusion
@@ -1,0 +1,1 @@
+foo.bar = ${value}

--- a/testData/fusion/codeInsight/intention/mergeOnlyFusionPathUp.before.fusion
+++ b/testData/fusion/codeInsight/intention/mergeOnlyFusionPathUp.before.fusion
@@ -1,0 +1,3 @@
+foo {
+    b<caret>ar = ${value}
+}

--- a/testData/fusion/codeInsight/intention/mergeSingleFusionPathUp.after.fusion
+++ b/testData/fusion/codeInsight/intention/mergeSingleFusionPathUp.after.fusion
@@ -1,0 +1,4 @@
+foo {
+    baz = ${value2}
+}
+foo.bar = ${value}

--- a/testData/fusion/codeInsight/intention/mergeSingleFusionPathUp.before.fusion
+++ b/testData/fusion/codeInsight/intention/mergeSingleFusionPathUp.before.fusion
@@ -1,0 +1,4 @@
+foo {
+    b<caret>ar = ${value}
+    baz = ${value2}
+}

--- a/testData/fusion/codeInsight/intention/splitFusionPath.after.fusion
+++ b/testData/fusion/codeInsight/intention/splitFusionPath.after.fusion
@@ -1,0 +1,3 @@
+foo {
+    bar.baz = ${value}
+}

--- a/testData/fusion/codeInsight/intention/splitFusionPath.before.fusion
+++ b/testData/fusion/codeInsight/intention/splitFusionPath.before.fusion
@@ -1,0 +1,1 @@
+foo.<caret>bar.baz = ${value}


### PR DESCRIPTION
Adds intentions to work with fusion paths.

## Split path at delimiter at caret
```
foo.<caret>.bar.baz = 'value'

###

foo {
  bar.baz = 'value'
}
```
Motivation: start with a first deep override and notice that an additional expression in that block is necessary. Breaking the path and wrapping it in braces is somehow super buggy..

Only one block will be created at a time. I was thinking about having some option or multiple intentions to break up either the current or all path segments. Could be improved, if someone has an idea how this should behave.

## Merge path up into surrounding block
```
foo {
  b<caret>ar.baz = 'value'
  qux = 12
}

###

foo {
  qux = 12
}
foo.bar.baz = 'value'
```
Pretty much the reverse to splitting the path. If the block contains multiple paths, the path at the cursor will be pulled out and added after the block. An empty block will be removed.

## Group common fusion paths
```
renderer.@process<caret>.foo = ${...}
renderer.@process.bar = ${...}

###

renderer.@process {
  foo = ${...}
  bar = ${...}
}
```
Creates a new block for the common prefix (= the path before the caret at a path separator).

Unfortunately still a bit buggy with the amount of whitespace created. Also currently conflicts pretty hard with prototype instanciation (e.g. merge `array.key = ...` into `array = Neos.Fusion:DataStructure`) as a new block is created and the original block is removed.
Might be a relatively easy fix to look for a prefix-candidate that already is block candidate.
However in this case I currently create the PSI tree from a string because I couldn't get the newlines to be created at the correct positions.

There could be an argument whether this is the correct trigger for an action like this though: it affects more lines than the current one and I could imagine use-cases where I only want to merge this specific line into an existing block.
It could be possible to "collect" all other paths into a prefix block, however that might not exist.
Also, merging into a block might be a desired behavior of the normal split path intention. But it might be surprising, if it just does that.