### PR TITLE
BUGFIX: Fix platformPlugins deps for IntelliJ 2025.1 compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22IntelliLang
-platformPlugins = com.jetbrains.hackathon.indices.viewer:1.25,PsiViewer:233.2,com.jetbrains.php:251.23774.466
+platformPlugins = com.jetbrains.hackathon.indices.viewer:1.30,PsiViewer:251.175,com.jetbrains.php:251.23774.466
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins = org.intellij.intelliLang,com.intellij.css,org.jetbrains.plugins.yaml,com.intellij.modules.json,com.intellij.java,com.intellij.java-i18n,com.intellij.properties


### PR DESCRIPTION
Fixed `platformPlugins` gradle deps to fix errors in IntelliJ verification.