### PR TITLE
TASK: Fix IntelliJ Plugin Warning (Exceptions)

### DIFF
--- a/src/main/java/de/vette/idea/neos/lang/eel/formatter/EelCodeStyleSettingsProvider.java
+++ b/src/main/java/de/vette/idea/neos/lang/eel/formatter/EelCodeStyleSettingsProvider.java
@@ -20,14 +20,22 @@ package de.vette.idea.neos.lang.eel.formatter;
 
 import com.intellij.application.options.CodeStyleAbstractConfigurable;
 import com.intellij.application.options.CodeStyleAbstractPanel;
+import com.intellij.lang.Language;
 import com.intellij.psi.codeStyle.CodeStyleConfigurable;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider;
 import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
+import de.vette.idea.neos.lang.eel.EelLanguage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class EelCodeStyleSettingsProvider extends CodeStyleSettingsProvider {
+
+    @Nullable
+    @Override
+    public Language getLanguage() {
+        return EelLanguage.INSTANCE;
+    }
 
     @Nullable
     @Override

--- a/src/main/java/de/vette/idea/neos/lang/fusion/formatter/FusionCodeStyleSettingsProvider.java
+++ b/src/main/java/de/vette/idea/neos/lang/fusion/formatter/FusionCodeStyleSettingsProvider.java
@@ -20,14 +20,22 @@ package de.vette.idea.neos.lang.fusion.formatter;
 
 import com.intellij.application.options.CodeStyleAbstractConfigurable;
 import com.intellij.application.options.CodeStyleAbstractPanel;
+import com.intellij.lang.Language;
 import com.intellij.psi.codeStyle.CodeStyleConfigurable;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider;
 import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
+import de.vette.idea.neos.lang.fusion.FusionLanguage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FusionCodeStyleSettingsProvider extends CodeStyleSettingsProvider {
+
+    @Nullable
+    @Override
+    public Language getLanguage() {
+        return FusionLanguage.INSTANCE;
+    }
 
     @Nullable
     @Override

--- a/src/main/java/de/vette/idea/neos/lang/yaml/annotators/PrototypeLineMarkerProvider.java
+++ b/src/main/java/de/vette/idea/neos/lang/yaml/annotators/PrototypeLineMarkerProvider.java
@@ -69,11 +69,13 @@ public class PrototypeLineMarkerProvider implements LineMarkerProvider {
 
                 List<PsiElement> targets = ResolveEngine.getPrototypeDefinitions(el.getProject(), nodeTypeSplit[1], nodeTypeSplit[0]);
                 if (!targets.isEmpty()) {
+                    PsiElement keyLeaf = ((YAMLKeyValue) el).getKey();
+                    if (keyLeaf == null) continue;
                     RelatedItemLineMarkerInfo<PsiElement> info = NavigationGutterIconBuilder
                             .create(FusionIcons.PROTOTYPE)
                             .setTargets(targets)
                             .setTooltipText("Go to Fusion prototype")
-                            .createLineMarkerInfo(el);
+                            .createLineMarkerInfo(keyLeaf);
                     result.add(info);
                 }
             }


### PR DESCRIPTION
Resolves two PluginException warnings logged on startup.                                                                                                                                                       
                                                                                                                                                                                                                   
**(Fusion|Eel)CodeStyleSettingsProvider:** Override `getLanguage()` to return the respective `Language.INSTANCE` instead of relying on the deprecated fallback that derives a configurable ID from the localizable display name.

Exception:
```
com.intellij.diagnostic.PluginException: Legacy configurable id calculation mode from localizable name will be used for configurable class de.vette.idea.neos.lang.eel.formatter.EelCodeStyleSettingsProvider. Please override getConfigurableId or getLanguage. [Plugin: vette.neos]
```
 

**PrototypeLineMarkerProvider:** Pass the key leaf element (rather than the `YAMLKeyValue` itself) to `createLineMarkerInfo()`, which is now required for line markers. Also adds a null guard for the key element.

Exception:
```
#c.i.c.d.LineMarkerInfo - Performance warning: LineMarker is supposed to be registered for leaf elements only, but got: YAML key value (class org.jetbrains.yaml.psi.impl.YAMLKeyValueImpl) instead. First child: PsiElement(scalar key) (class com.intellij.psi.impl.source.tree.LeafPsiElement)
Please see LineMarkerProvider#getLineMarkerInfo(PsiElement) javadoc for detailed explanations.
```