### PR TITLE
Add compatibility with IntelliJ Platform 2026.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle
@@ -123,7 +123,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle
@@ -176,7 +176,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 25
 
       # Run Qodana inspections
       - name: Qodana - Code Inspection
@@ -214,7 +214,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Compatibility with 2026.2
+
 ## [1.26.0] - 2026-03-27
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,12 @@ sourceSets {
     }
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(providers.gradleProperty("javaVersion").get())
+    }
+}
+
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
     testImplementation(libs.junit)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,19 +2,19 @@ pluginGroup = com.github.cvette
 pluginName = neos-intellij-plugin
 pluginRepositoryUrl = https://github.com/cvette/intellij-neos
 # SemVer format -> https://semver.org
-pluginVersion = 1.26.0
+pluginVersion = 1.27.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 261
-pluginUntilBuild = 261.*
+pluginSinceBuild = 262
+pluginUntilBuild = 262.*
 
 platformType = IU
-platformVersion = 2026.1
+platformVersion = 2026.2
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22IntelliLang
-platformPlugins = com.jetbrains.hackathon.indices.viewer:1.32,PsiViewer:253.7181,com.jetbrains.php:261.22158.208
+platformPlugins = com.jetbrains.hackathon.indices.viewer:1.32,PsiViewer:2026.1,com.jetbrains.php:262.8665.176
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins = com.intellij.css,org.jetbrains.plugins.yaml,com.intellij.modules.json,com.intellij.java,com.intellij.java-i18n,com.intellij.properties
@@ -23,7 +23,7 @@ platformBundledModules = intellij.platform.langInjection
 grammarKitVersion = 2022.3.2
 jFlexVersion = 1.9.0
 
-javaVersion = 21
+javaVersion = 25
 
 gradleVersion = 9.4.1
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ junit = "4.13.2"
 
 # plugins
 changelog = "2.5.0"
-intelliJPlatform = "2.14.0"
+intelliJPlatform = "2.18.1"
 grammarKit = "2023.3.0.3"
 qodana = "2026.1.0"
 kover = "0.9.8"

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -2,8 +2,8 @@
 # https://www.jetbrains.com/help/qodana/qodana-yaml.html
 
 version: 1.0
-linter: jetbrains/qodana-jvm-community:2025.2
-projectJDK: "21"
+linter: jetbrains/qodana-jvm-community:2026.1
+projectJDK: "25"
 profile:
   name: qodana.recommended
 exclude:

--- a/src/main/grammars/FusionLexer.flex
+++ b/src/main/grammars/FusionLexer.flex
@@ -5,7 +5,6 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.TokenType;
 import de.vette.idea.neos.lang.fusion.psi.FusionTypes;
 import de.vette.idea.neos.lang.fusion.psi.FusionValueDsl;
-import groovyjarjarantlr.Token;
 
 %%
 

--- a/src/main/java/de/vette/idea/neos/errorReporting/SentryErrorReporter.java
+++ b/src/main/java/de/vette/idea/neos/errorReporting/SentryErrorReporter.java
@@ -1,8 +1,5 @@
 package de.vette.idea.neos.errorReporting;
 
-import com.intellij.diagnostic.*;
-import com.intellij.ide.plugins.PluginManagerCore;
-import com.intellij.ide.plugins.PluginUtil;
 import com.intellij.idea.IdeaLogger;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
@@ -10,7 +7,6 @@ import com.intellij.openapi.diagnostic.ErrorReportSubmitter;
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent;
 import com.intellij.openapi.diagnostic.SubmittedReportInfo;
 import com.intellij.openapi.extensions.PluginDescriptor;
-import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.NlsActions;
 import com.intellij.openapi.util.NlsContexts;
@@ -32,27 +28,25 @@ public class SentryErrorReporter extends ErrorReportSubmitter {
     }
 
     @SuppressWarnings("BooleanMethodNameMustStartWithQuestion")
-    private static boolean doSubmit(final IdeaLoggingEvent[] events,
-                                    final Component parentComponent,
-                                    final Consumer<? super SubmittedReportInfo> consumer,
-                                    final String description) {
+    private boolean doSubmit(final IdeaLoggingEvent[] events,
+                             final Component parentComponent,
+                             final Consumer<? super SubmittedReportInfo> consumer,
+                             final String description) {
         Sentry.init(options -> {
             options.setDsn("https://078a292636084b9581b1bb73fbd3e488@o577996.ingest.sentry.io/5733915");
         });
 
         ArrayList<String> eventIds = new ArrayList<>();
         for (IdeaLoggingEvent ideaEvent : events) {
-            if (ideaEvent instanceof IdeaReportingEvent && ideaEvent.getData() instanceof AbstractMessage) {
-                Throwable ex = ((AbstractMessage) ideaEvent.getData()).getThrowable();
-
+            Throwable ex = ideaEvent.getThrowable();
+            if (ex != null) {
                 SentryEvent sentryEvent = new SentryEvent();
 
                 if (sentryEvent.getEventId() != null) {
                     eventIds.add(sentryEvent.getEventId().toString());
                 }
 
-                PluginId pluginId = PluginUtil.getInstance().findPluginId(ex);
-                PluginDescriptor plugin = PluginManagerCore.getPlugin(pluginId);
+                PluginDescriptor plugin = getPluginDescriptor();
                 if (plugin != null) {
                     sentryEvent.setRelease(plugin.getVersion());
                 }

--- a/src/main/java/de/vette/idea/neos/lang/eel/formatter/EelCodeStyleSettingsProvider.java
+++ b/src/main/java/de/vette/idea/neos/lang/eel/formatter/EelCodeStyleSettingsProvider.java
@@ -20,14 +20,22 @@ package de.vette.idea.neos.lang.eel.formatter;
 
 import com.intellij.application.options.CodeStyleAbstractConfigurable;
 import com.intellij.application.options.CodeStyleAbstractPanel;
+import com.intellij.lang.Language;
 import com.intellij.psi.codeStyle.CodeStyleConfigurable;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider;
 import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
+import de.vette.idea.neos.lang.eel.EelLanguage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class EelCodeStyleSettingsProvider extends CodeStyleSettingsProvider {
+
+    @Nullable
+    @Override
+    public Language getLanguage() {
+        return EelLanguage.INSTANCE;
+    }
 
     @Nullable
     @Override

--- a/src/main/java/de/vette/idea/neos/lang/fusion/formatter/FusionCodeStyleSettingsProvider.java
+++ b/src/main/java/de/vette/idea/neos/lang/fusion/formatter/FusionCodeStyleSettingsProvider.java
@@ -20,14 +20,22 @@ package de.vette.idea.neos.lang.fusion.formatter;
 
 import com.intellij.application.options.CodeStyleAbstractConfigurable;
 import com.intellij.application.options.CodeStyleAbstractPanel;
+import com.intellij.lang.Language;
 import com.intellij.psi.codeStyle.CodeStyleConfigurable;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider;
 import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
+import de.vette.idea.neos.lang.fusion.FusionLanguage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FusionCodeStyleSettingsProvider extends CodeStyleSettingsProvider {
+
+    @Nullable
+    @Override
+    public Language getLanguage() {
+        return FusionLanguage.INSTANCE;
+    }
 
     @Nullable
     @Override

--- a/src/main/java/de/vette/idea/neos/lang/fusion/structure/FusionTreeElement.java
+++ b/src/main/java/de/vette/idea/neos/lang/fusion/structure/FusionTreeElement.java
@@ -19,9 +19,13 @@
 package de.vette.idea.neos.lang.fusion.structure;
 
 import com.intellij.ide.structureView.StructureViewTreeElement;
-import com.intellij.ide.structureView.impl.common.PsiTreeElementBase;
+import com.intellij.ide.util.treeView.smartTree.TreeElement;
+import com.intellij.navigation.ItemPresentation;
+import com.intellij.pom.Navigatable;
 import com.intellij.psi.NavigatablePsiElement;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.SmartPointerManager;
+import com.intellij.psi.SmartPsiElementPointer;
 import de.vette.idea.neos.lang.fusion.icons.FusionIcons;
 import de.vette.idea.neos.lang.fusion.psi.*;
 import org.jetbrains.annotations.NotNull;
@@ -32,10 +36,48 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
-public class FusionTreeElement extends PsiTreeElementBase<PsiElement> {
+public class FusionTreeElement implements StructureViewTreeElement, ItemPresentation {
+
+    private final SmartPsiElementPointer<PsiElement> myElementPointer;
 
     FusionTreeElement(PsiElement element) {
-        super(element);
+        myElementPointer = SmartPointerManager.getInstance(element.getProject()).createSmartPsiElementPointer(element);
+    }
+
+    @Nullable
+    public PsiElement getElement() {
+        return myElementPointer.getElement();
+    }
+
+    @Override
+    public PsiElement getValue() {
+        return getElement();
+    }
+
+    @NotNull
+    @Override
+    public ItemPresentation getPresentation() {
+        return this;
+    }
+
+    @Override
+    public TreeElement @NotNull [] getChildren() {
+        Collection<StructureViewTreeElement> children = getChildrenBase();
+        return children.toArray(StructureViewTreeElement.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void navigate(boolean requestFocus) {
+        PsiElement element = getElement();
+        if (element instanceof Navigatable) {
+            ((Navigatable) element).navigate(requestFocus);
+        }
+    }
+
+    @Override
+    public boolean canNavigateToSource() {
+        PsiElement element = getElement();
+        return element instanceof Navigatable && ((Navigatable) element).canNavigateToSource();
     }
 
     @Override
@@ -53,7 +95,6 @@ public class FusionTreeElement extends PsiTreeElementBase<PsiElement> {
     }
 
     @NotNull
-    @Override
     public Collection<StructureViewTreeElement> getChildrenBase() {
         Collection<StructureViewTreeElement> result = new ArrayList<>();
 


### PR DESCRIPTION
I vibe coded this, so maybe double check these changes, but this is what changed:

## Add compatibility with IntelliJ Platform 2026.2

Fixes https://github.com/cvette/intellij-neos/issues/494

Makes the plugin build, test, and verify cleanly against IntelliJ IDEA / PhpStorm 2026.2 (IU-262.8665.258). Verified with the JetBrains Plugin Verifier — no compatibility problems and no internal API usages remain; all 23 tests pass.

### Platform & dependency updates

- Target platform bumped to **2026.2**, plugin range `262` – `262.*`
- PHP plugin → `262.8665.176`, PsiViewer → `2026.1`
- IntelliJ Platform Gradle Plugin `2.14.0` → `2.18.1` (2.14.0 fails to parse the 2026.2 module descriptors with a `MissingFieldException`)

### Java 25

The 2026.2 platform jars are compiled for Java 25, so JDK 21 can neither compile against them nor run the Grammar-Kit lexer/parser generators. This PR:

- sets `javaVersion = 25` and adds an explicit Gradle Java toolchain (auto-provisioned via the existing foojay resolver)
- bumps `java-version` to 25 in the GitHub workflows
- updates `qodana.yaml` (`projectJDK: 25`, linter `2026.1`)

### Code changes

- **`FusionTreeElement`**: `com.intellij.ide.structureView.impl.common.PsiTreeElementBase` was moved out of the core platform into the new `intellij.platform.structureView` content module, which even the latest Plugin Verifier (1.408) cannot resolve yet. The class now implements `StructureViewTreeElement` / `ItemPresentation` directly, backed by a `SmartPsiElementPointer` — same presentation, icon, and children behavior as before. (JetBrains' own YAML plugin takes the same approach with its `DuplicatedPsiTreeElementBase`.)
- **`SentryErrorReporter`**: replaced `IdeaReportingEvent` / `AbstractMessage` / `PluginManagerCore.getPlugin` — now internal API and deprecated for removal — with the public `IdeaLoggingEvent.getThrowable()` and the submitter's own `getPluginDescriptor()`. Behavior unchanged.
- **`FusionLexer.flex`**: removed a stray, unused `import groovyjarjarantlr.Token;` that only compiled because older IDE distributions bundled a shaded groovy jar (gone in 2026.2).

### Notes

- The dev-only Index Viewer plugin (`com.jetbrains.hackathon.indices.viewer`) has no 262-compatible release yet; it stays pinned at 1.32 and will simply be disabled in the `runIde` sandbox until an update is published.
- The verifier still reports a few informational warnings (deprecated stub methods, experimental inlay-hints API) that don't block this release but will need attention in a future platform version.